### PR TITLE
Add command to not close tabs in sidebar

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ export default class AdvancedCloseTab extends Plugin {
 
   addCommands() {
     this.addCommand({
-      id: 'advanced-close-tab-close-current-tab',
+      id: 'close-current-tab',
       name: 'Close current tab',
       callback: () => {
         const workspace = this.app.workspace;
@@ -26,8 +26,8 @@ export default class AdvancedCloseTab extends Plugin {
     });
     
     this.addCommand({
-      id: 'advanced-close-tab-close-current-tab-if-not-in-sidebar',
-      name: "Close current tab (if not in sidebar)",
+      id: 'close-current-tab-if-in-main-area',
+      name: "Close current tab (if in main area)",
       callback: () => {
         const workspace = this.app.workspace;
 
@@ -52,7 +52,7 @@ export default class AdvancedCloseTab extends Plugin {
     });
     
     this.addCommand({
-      id: 'advanced-close-tab-close-all-tabs',
+      id: 'close-all-tabs',
       name: 'Close all tabs',
       callback: () => {
         const workspace = this.app.workspace;
@@ -64,7 +64,7 @@ export default class AdvancedCloseTab extends Plugin {
     });
 
     this.addCommand({
-      id: 'advanced-close-tab-close-all-tabs-in-main-area',
+      id: 'close-all-tabs-in-main-area',
       name: 'Close all tabs in main area',
       callback: () => {
         const workspace = this.app.workspace;

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,8 +26,8 @@ export default class AdvancedCloseTab extends Plugin {
     });
     
     this.addCommand({
-      id: 'advanced-close-tab-close-current-tab-if-not-in-sidebar',
-      name: "Close current tab (if not in sidebar)",
+      id: 'close-current-tab-if-in-main-area',
+      name: "Close current tab (if in main area)",
       callback: () => {
         const workspace = this.app.workspace;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ export default class AdvancedCloseTab extends Plugin {
 
   addCommands() {
     this.addCommand({
-      id: 'close-current-tab',
+      id: 'advanced-close-tab-close-current-tab',
       name: 'Close current tab',
       callback: () => {
         const workspace = this.app.workspace;
@@ -26,8 +26,8 @@ export default class AdvancedCloseTab extends Plugin {
     });
     
     this.addCommand({
-      id: 'close-current-tab-if-in-main-area',
-      name: "Close current tab (if in main area)",
+      id: 'advanced-close-tab-close-current-tab-if-not-in-sidebar',
+      name: "Close current tab (if not in sidebar)",
       callback: () => {
         const workspace = this.app.workspace;
 
@@ -58,7 +58,7 @@ export default class AdvancedCloseTab extends Plugin {
     });
     
     this.addCommand({
-      id: 'close-all-tabs',
+      id: 'advanced-close-tab-close-all-tabs',
       name: 'Close all tabs',
       callback: () => {
         const workspace = this.app.workspace;
@@ -70,7 +70,7 @@ export default class AdvancedCloseTab extends Plugin {
     });
 
     this.addCommand({
-      id: 'close-all-tabs-in-main-area',
+      id: 'advanced-close-tab-close-all-tabs-in-main-area',
       name: 'Close all tabs in main area',
       callback: () => {
         const workspace = this.app.workspace;

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,10 +40,10 @@ export default class AdvancedCloseTab extends Plugin {
         const leaf = this.app.workspace.getLeafById(activeLeaf.id);
         if (!leaf) return;
 
-        const isTabGroupInMainArea = app.workspace.rootSplit.children.find(c => {
-          return c.id === app.workspace.activeTabGroup.id
-        })
-        if(!isTabGroupInMainArea){
+        //isOnSidebar
+        const root = activeLeaf.getRoot()
+        const containerEl = root.containerEl.outerHTML.split('>')
+        if(containerEl[0].includes("left") || containerEl[0].includes("right")){
           return;
         }else{
           this.detachLeafIfUnpinned(leaf);

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,7 +24,33 @@ export default class AdvancedCloseTab extends Plugin {
         this.detachLeafIfUnpinned(leaf);
       },
     });
+    
+    this.addCommand({
+      id: 'advanced-close-tab-close-current-tab-if-not-in-sidebar',
+      name: "Close current tab (if not in sidebar)",
+      callback: () => {
+        const workspace = this.app.workspace;
 
+        // @ts-expect-error workspace.activeTabGroup is not a public field
+        const activeTabGroup = workspace.activeTabGroup;
+        const currentTab = activeTabGroup.currentTab;
+        const activeLeaf = activeTabGroup.children[currentTab];
+        if (!activeLeaf) return;
+
+        const leaf = this.app.workspace.getLeafById(activeLeaf.id);
+        if (!leaf) return;
+
+        //isOnSidebar
+        const root = activeLeaf.getRoot()
+        const containerEl = root.containerEl.outerHTML.split('>')
+        if(containerEl[0].includes("left") || containerEl[0].includes("right")){
+          return;
+        }else{
+          this.detachLeafIfUnpinned(leaf);
+        }
+      },
+    });
+    
     this.addCommand({
       id: 'advanced-close-tab-close-all-tabs',
       name: 'Close all tabs',

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,10 +40,10 @@ export default class AdvancedCloseTab extends Plugin {
         const leaf = this.app.workspace.getLeafById(activeLeaf.id);
         if (!leaf) return;
 
-        //isOnSidebar
-        const root = activeLeaf.getRoot()
-        const containerEl = root.containerEl.outerHTML.split('>')
-        if(containerEl[0].includes("left") || containerEl[0].includes("right")){
+        const isTabGroupInMainArea = app.workspace.rootSplit.children.find(c => {
+          return c.id === app.workspace.activeTabGroup.id
+        })
+        if(!isTabGroupInMainArea){
           return;
         }else{
           this.detachLeafIfUnpinned(leaf);

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,10 +40,16 @@ export default class AdvancedCloseTab extends Plugin {
         const leaf = this.app.workspace.getLeafById(activeLeaf.id);
         if (!leaf) return;
 
-        //isOnSidebar
-        const root = activeLeaf.getRoot()
-        const containerEl = root.containerEl.outerHTML.split('>')
-        if(containerEl[0].includes("left") || containerEl[0].includes("right")){
+        const isTabGroupInRightSidebar = app.workspace.rightSplit.children.find(c => {
+          return c.id === app.workspace.activeTabGroup.id
+        });
+        const isTabGroupInLeftSidebar = app.workspace.leftSplit.children.find(c => {
+          return c.id === app.workspace.activeTabGroup.id
+        });
+        
+        if(isTabGroupInRightSidebar){
+          return;
+        }else if(isTabGroupInLeftSidebar){
           return;
         }else{
           this.detachLeafIfUnpinned(leaf);


### PR DESCRIPTION
I made this request because of the reasons listed below. I am new to programming, so sorry if I have made any mistakes.

## Purposes

### 1. Prevent closing plugin tabs in the sidebar

I open many plugins in the sidebar, and for such use cases, closing tabs by `ctrl + W` in the sidebar is very problematic because tabs opened by plugins can't be pinned. The context menu is enough to close tabs in the sidebar because I use the sidebar as a stable workspace.

### 2. To open Daily Notes in the sidebar

I tried to open Daily Notes in the sidebar, but it wasn't comfortable because it closes when I press `ctrl + W` by mistake. If it's pinned, it won't switch to the next day's Daily Notes automatically.

## Changes

- Added command "Close current tab (if not in the sidebar)"